### PR TITLE
ignore: Use environment variables for the demo and clean up README.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -2,21 +2,21 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Video.js Sandbox</title>
-
-  <!-- Load the source files -->
-
+  <title>player-loader-webpack-plugin Demo</title>
+  <style type="text/css">
+    .video-js {
+      width: 900px;
+      height: 504px;
+    }
+  </style>
 </head>
 <body>
-  <video id="vid1" class="video-js vjs-default-skin" controls preload="auto" width="640" height="264"
-      poster="http://vjs.zencdn.net/v/oceans.png"
-      data-setup='{}'>
-    <source src="http://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
-    <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
-    <source src="http://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
-  </video>
-
+  <h1>player-loader-webpack-plugin Demo</h1>
+  <!--
+    data-player and data-embed are left off this player so that it is not
+    auto set up
+  -->
+  <video class="video-js" controls></video>
   <script src="./dist.js"></script>
-
 </body>
 </html>

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,10 +1,15 @@
 import window from 'global/window';
 import document from 'global/document';
 
-// the brightcove player of your choosing, defined in webpack.config.js
-// will be prepended to your bundle. The bc function will be available in your
-// entry point.
-const player = window.bc(document.getElementById('vid1'));
+// The Brightcove Player of your choosing, defined in webpack.config.js,
+// will be prepended to your bundle. The bc function will be available in
+// your entry point.
+const player = window.bc(document.querySelector('video'));
 
-/* eslint-disable no-console */
-console.log(player);
+// Expose the player globally, so we can easily interact with it in the
+// browser console. It is not recommended that you do this in production!
+window.player = player;
+
+// Set a poster image and an MP4 source, for demo purposes.
+player.poster('http://vjs.zencdn.net/v/oceans.png');
+player.src({src: 'https://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4'});

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -2,17 +2,16 @@
 const path = require('path');
 const PlayerLoader = require('../src/index.js');
 
-let accountId = '';
-
-if (process.argv[5]) {
-  accountId = process.argv[5].trim();
-}
+const accountId = process.env.BC_ACCOUNT_ID;
 
 if (!accountId) {
-  console.error('Please pass a valid accountId to this command. ex: `npm run demo -- 123456789`');
+  console.error('You must set a valid `BC_ACCOUNT_ID` environment variable!');
   console.error();
   process.exit(1);
 }
+
+const playerId = process.env.BC_PLAYER_ID || 'default';
+const embedId = process.env.BC_EMBED_ID || 'default';
 
 module.exports = {
   entry: path.resolve(__dirname, 'index.js'),
@@ -22,6 +21,6 @@ module.exports = {
   },
   mode: 'development',
   plugins: [
-    new PlayerLoader({accountId})
+    new PlayerLoader({accountId, embedId, playerId})
   ]
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "player"
   ],
   "vjsstandard": {
-    "ignore": ["demo/dist.js"]
+    "ignore": ["demo/**"]
   },
   "author": "Brightcove, Inc.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -7,17 +7,24 @@
     "version": "node scripts/version.js",
     "lint": "vjsstandard",
     "predemo": "rm -f ./demo/dist.js",
-    "demo": "webpack --config ./demo/webpack.config.js -- ",
+    "demo": "webpack --config ./demo/webpack.config.js",
     "postdemo": "npm run demoserver",
     "demoserver": "http-server demo -p 9999",
     "preversion": "npm run lint",
     "prepush": "npm run lint"
   },
-  "keywords": [],
-  "author": {
-    "name": "Brandon Casey",
-    "email": "branonocasey@gmail.com"
+  "keywords": [
+    "webpack",
+    "plugin",
+    "brightcove",
+    "videojs",
+    "video",
+    "player"
+  ],
+  "vjsstandard": {
+    "ignore": ["demo/dist.js"]
   },
+  "author": "Brightcove, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
     "@brightcove/player-loader": "^1.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ class PlayerLoaderPlugin {
     const url = PlayerLoader.getUrl(settings);
 
     this.playerPromise = request.get(url).catch(function(err) {
-
       console.error('Failed to get a player at ' + url + ' double check your options');
       console.error(err);
       console.error();
@@ -40,7 +39,6 @@ class PlayerLoaderPlugin {
         });
         callback();
       });
-
     });
   }
 }


### PR DESCRIPTION
I felt like the README was a bit too much - particularly when describing the `bc()` function signature. It should be largely the same as `videojs()`, so I think we can just say that. Other changes include grammar, spelling, and organization (moved Options to the bottom was the biggest change).

Also, I couldn't get the demo working via the command-line arguments, but using environment variables instead worked fine. Added support for specifying player ID and embed ID, as well.