### PR TITLE
Adding backward support for webpack 3 & fixed behaviour of prependTo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The official webpack plugin for the Brightcove Player.
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Installation](#installation)
+- [Compatibility](#compatibility)
 - [Basic Usage](#basic-usage)
 - [How it Works](#how-it-works)
   - [Limitations](#limitations)
@@ -21,7 +22,6 @@ The official webpack plugin for the Brightcove Player.
 - [Putting it All Together](#putting-it-all-together)
 - [Running the Demo Project](#running-the-demo-project)
 - [Options](#options)
-  - [`backwardCompatible`](#backwardcompatible)
   - [`prependTo`](#prependto)
   - [`accountId`](#accountid)
   - [`embedId`](#embedid)
@@ -36,6 +36,10 @@ To install, use:
 ```sh
 npm install --save-dev @brightcove/player-loader-webpack-plugin
 ```
+
+## Compatibility
+
+This webpack plugin supports webpack 3.x & webpack 4.x
 
 ## Basic Usage
 First, require the plugin at the top of your `webpack.config.js`:
@@ -176,12 +180,6 @@ This project's Git repository comes with a working demo project.
 1. If everything succeeds, wait for the web server to start then open `http://localhost:9999/` in the browser.
 
 ## Options
-
-### `backwardCompatible`
-* *Type:* `boolean`
-
-By default this plugin works with webpack@4.x but to support webpack@3.x (like for Ionic 3/4), you can pass `backwardCompatible: true` to
- options.
 
 ### `prependTo`
 * *Type:* `array|string`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The official webpack plugin for the Brightcove Player.
 - [Putting it All Together](#putting-it-all-together)
 - [Running the Demo Project](#running-the-demo-project)
 - [Options](#options)
+  - [`backwardCompatible`](#backwardcompatible)
   - [`prependTo`](#prependto)
   - [`accountId`](#accountid)
   - [`embedId`](#embedid)
@@ -175,6 +176,12 @@ This project's Git repository comes with a working demo project.
 1. If everything succeeds, wait for the web server to start then open `http://localhost:9999/` in the browser.
 
 ## Options
+
+### `backwardCompatible`
+* *Type:* `boolean`
+
+By default this plugin works with webpack@4.x but to support webpack@3.x (like for Ionic 3/4), you can pass `backwardCompatible: true` to
+ options.
 
 ### `prependTo`
 * *Type:* `array|string`

--- a/src/index.js
+++ b/src/index.js
@@ -33,12 +33,12 @@ class PlayerLoaderPlugin {
   }
 
   apply(compiler) {
-    if (this.settings_.backwardCompatible) {
-      // webpack@3 syntax
-      compiler.plugin('emit', this.downloadAndAppendPlayer.bind(this));
-    } else {
+    if (compiler.hooks && compiler.hooks.emit) {
       // webpack@4 syntax
       compiler.hooks.emit.tapAsync('PlayerLoaderPlugin', this.downloadAndAppendPlayer.bind(this));
+    } else {
+      // webpack@3 syntax
+      compiler.plugin('emit', this.downloadAndAppendPlayer.bind(this));
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,17 @@ class PlayerLoaderPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.emit.tapAsync('PlayerLoaderPlugin', (compilation, callback) => {
+    if (this.settings_.backwardCompatible) {
+      // webpack@3 syntax
+      compiler.plugin('emit', this.downloadAndAppendPlayer.bind(this));
+    } else {
+      // webpack@4 syntax
+      compiler.hooks.emit.tapAsync('PlayerLoaderPlugin', this.downloadAndAppendPlayer.bind(this));
+    }
+  }
+
+  downloadAndAppendPlayer(compilation, callback) {
+      // Keeping the indentation to 4 to avoid unnecessary diff in GitHub
       request.get(this.playerUrl).then((playerjs) => {
         let assets = Object.keys(compilation.assets);
 
@@ -67,7 +77,6 @@ class PlayerLoaderPlugin {
         console.error();
         process.exit(1);
       });
-    });
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class PlayerLoaderPlugin {
 
       // if prependTo is specified though, we prepend to anything that is listed
       } else {
-        assets = assets.filter((filename) => this.settings_.prependTo.indexOf(filename) === -1);
+        assets = assets.filter((filename) => this.settings_.prependTo.indexOf(filename) !== -1);
       }
 
       if (!assets.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -43,40 +43,39 @@ class PlayerLoaderPlugin {
   }
 
   downloadAndAppendPlayer(compilation, callback) {
-      // Keeping the indentation to 4 to avoid unnecessary diff in GitHub
-      request.get(this.playerUrl).then((playerjs) => {
-        let assets = Object.keys(compilation.assets);
+    request.get(this.playerUrl).then((playerjs) => {
+      let assets = Object.keys(compilation.assets);
 
-        // normally we filter out all non .js outputs, and choose prepend to
-        // only the first output
-        if (typeof this.settings_.prependTo === 'undefined') {
-          // filter out non js files
-          assets = assets.filter((filename) => path.extname(filename) === '.js');
+      // normally we filter out all non .js outputs, and choose prepend to
+      // only the first output
+      if (typeof this.settings_.prependTo === 'undefined') {
+        // filter out non js files
+        assets = assets.filter((filename) => path.extname(filename) === '.js');
 
-          // only prepend to the first one
-          assets = [assets[0]];
+        // only prepend to the first one
+        assets = [assets[0]];
 
-        // if prependTo is specified though, we prepend to anything that is listed
-        } else {
-          assets = assets.filter((filename) => this.settings_.prependTo.indexOf(filename) === -1);
-        }
+      // if prependTo is specified though, we prepend to anything that is listed
+      } else {
+        assets = assets.filter((filename) => this.settings_.prependTo.indexOf(filename) === -1);
+      }
 
-        if (!assets.length) {
-          console.error('webpack-player-loader-plugin: did not find anything to prepend the player to!');
-          console.error();
-          process.exit(1);
-        }
-
-        assets.forEach(function(file) {
-          compilation.assets[file] = new ConcatSource(playerjs, compilation.assets[file]);
-        });
-        callback();
-      }).catch(function(err) {
-        console.error('Failed to get a player at ' + this.playerUrl + ' double check your options');
-        console.error(err);
+      if (!assets.length) {
+        console.error('webpack-player-loader-plugin: did not find anything to prepend the player to!');
         console.error();
         process.exit(1);
+      }
+
+      assets.forEach(function(file) {
+        compilation.assets[file] = new ConcatSource(playerjs, compilation.assets[file]);
       });
+      callback();
+    }).catch(function(err) {
+      console.error('Failed to get a player at ' + this.playerUrl + ' double check your options');
+      console.error(err);
+      console.error();
+      process.exit(1);
+    });
   }
 }
 


### PR DESCRIPTION
## Changes

### Backward support

By default plugin supports webpack 4.x version with the syntax. webpack 4.x has partial support with webpack 3.x so to support webpack 3.x as well (like used by Ionic 3/4), a boolean option `backwardCompatible` is added.

### `prependTo` option usage

### Actual Behaviour

Passing `prependTo` option prepend the Brightcove player JS to all assets excluding what is give in the list.

### Expected Behaviour

Passing `prependTo` option should prepend the Brightcove player JS to the given asset names.