### PR TITLE
Fix prependTo option and test script

### DIFF
--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -20,6 +20,6 @@ module.exports = {
     path: path.resolve(__dirname)
   },
   plugins: [
-    new PlayerLoader({accountId, embedId, playerId, prependTo: 'demo.js'})
+    new PlayerLoader({accountId, embedId, playerId, prependTo: 'dist.js'})
   ]
 };

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class PlayerLoaderPlugin {
 
       // if prependTo is specified though, we prepend to anything that is listed
       } else {
-        assets = assets.filter((filename) => this.settings_.prependTo.indexOf(filename) === -1);
+        assets = assets.filter((filename) => this.settings_.prependTo.indexOf(filename) !== -1);
       }
 
       if (!assets.length) {


### PR DESCRIPTION
prependTo was fixed in https://github.com/brightcove/player-loader-webpack-plugin/commit/b5617e6347121f88e37052959a2cb3b05bed1bf2 but then reverted in https://github.com/brightcove/player-loader-webpack-plugin/commit/23c367a4f9135bd5da06d6c86382794f8f59e035

Mostly, I suspect it was reverted because the `test-webpack.js` was now erroring out, so I fixed that too. Even though this is a bugfix, I think it's technically a major change since it completely inverts how the code behaves. Let me know if you have any questions. Thanks!